### PR TITLE
Update yn_prompt message to reflect available options

### DIFF
--- a/bdep/sync.cxx
+++ b/bdep/sync.cxx
@@ -709,7 +709,7 @@ namespace bdep
 
         add_info (text);
 
-        if (!yn_prompt ("continue? [Y/n]", 'y'))
+        if (!yn_prompt ("continue? [y/n]", 'y'))
         {
           // The dependency information have already been printed, so
           // suppress printing it repeatedly by the above exception guard.


### PR DESCRIPTION
This PR updates the "sync" yn_prompt message displayed when prompting for confirmation to match the available options ('Y' to 'y').
